### PR TITLE
fix max int

### DIFF
--- a/group.go
+++ b/group.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	NodeCountUnlimited = math.MaxInt64
+	NodeCountUnlimited = math.MaxInt
 )
 
 type Group struct {


### PR DESCRIPTION
math.MaxInt64 can't assign to type int under windows

![img_v2_dfdf84cd-dfd1-4632-85ab-767fb1827b4l](https://github.com/RangerCD/cslb/assets/6017354/734d323f-6554-45a2-9c53-aac390579312)
